### PR TITLE
docs: warn mobile users about WASM instability

### DIFF
--- a/web/.gitignore
+++ b/web/.gitignore
@@ -2,3 +2,4 @@ _site
 *_ipynb
 
 /.quarto/
+!*.html

--- a/web/_quarto.yml
+++ b/web/_quarto.yml
@@ -151,8 +151,9 @@ format:
     theme: darkly
     css: styles.css
     include-in-header:
-      - text: |
-          <script defer src="https://umami.peter.gy/script.js" data-website-id="6da82a32-91fa-4705-9038-888abf4cdcd8"></script>
+      - analytics.html
+    include-after-body:
+      - js.html
     grid:
       sidebar-width: 300px
       body-width: 800px

--- a/web/analytics.html
+++ b/web/analytics.html
@@ -1,0 +1,1 @@
+<script defer src="https://umami.peter.gy/script.js" data-website-id="6da82a32-91fa-4705-9038-888abf4cdcd8"></script>

--- a/web/js.html
+++ b/web/js.html
@@ -1,0 +1,51 @@
+<!-- 
+  This script adds a warning banner for mobile users since Gradio Lite is not fully optimized 
+  for mobile devices. The warning appears at the top of the page and can be dismissed.
+-->
+
+<script>
+  document.addEventListener('DOMContentLoaded', function() {
+    // Check if the device is mobile and has Gradio elements
+    const isMobileDevice = /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(
+      navigator.userAgent
+    );
+    const hasGradioElements = document.querySelector('.quarto-gradio');
+
+    if (isMobileDevice && hasGradioElements) {
+      // Create mobile warning element
+      const mobileWarning = document.createElement('div');
+      mobileWarning.id = 'mobile-warning';
+      mobileWarning.className = 'alert alert-warning';
+
+      const warningContent = `
+        <div class="d-flex justify-content-between align-items-center">
+          <div>
+            <i class="bi bi-exclamation-triangle me-2"></i>
+            <strong>Mobile Device Detected</strong><br>
+            Gradio Lite is currently optimized for desktop browsers. 
+            Interactive components may not work as expected on your current device.
+          </div>
+          <button type="button" class="btn-close" aria-label="Close"></button>
+        </div>
+      `;
+      mobileWarning.innerHTML = warningContent;
+
+      // Style the warning to be sticky
+      Object.assign(mobileWarning.style, {
+        position: 'sticky',
+        top: '0',
+        zIndex: '1050', 
+        width: '100%',
+        margin: '0',
+        borderRadius: '0'
+      });
+
+      // Add warning to top of body
+      document.body.insertBefore(mobileWarning, document.body.firstChild);
+
+      // Handle close button click
+      const closeButton = mobileWarning.querySelector('.btn-close');
+      closeButton.addEventListener('click', () => mobileWarning.remove());
+    }
+  });
+</script>


### PR DESCRIPTION
Currently, when visiting the site from mobile, all the WASM-based examples break.
The root issue might have been already fixed upstream by Pyodide https://github.com/pyodide/pyodide/pull/5445 by skipping wasm-gc when appropriate, but [@gradio/lite](https://www.npmjs.com/package/@gradio/lite) will need to bump its Pyodide version to 0.27.3 to include the fix.

Until then, this PR adds:

1. **Mobile-Specific Warning**:
   - Adding a sticky warning banner for mobile devices
   - Making the warning dismissible with a close button
   - Clearly communicating that Gradio Lite is optimized for desktop and issues are expected on mobile

2. **Code Organization**:
   - Moving analytics code to a dedicated `analytics.html` file
   - Moving JavaScript functionality to a dedicated `js.html` file
   - Cleaning up the _quarto.yml file for better maintainability

### Screenshots

![418338731-7b3877e7-34e1-4e81-a86a-21447496b5cd (1)](https://github.com/user-attachments/assets/86d5935e-97d4-42c8-ad7e-10e80c01d1cf)
