### PR TITLE
chore: configure `og:image` and `og:description`

### DIFF
--- a/web/_metadata.yml
+++ b/web/_metadata.yml
@@ -1,0 +1,1 @@
+image: /public/quarto-gradio-bg.png

--- a/web/_quarto.yml
+++ b/web/_quarto.yml
@@ -4,9 +4,10 @@ project:
 
 website:
   title: "Quarto 🔹🔸 Gradio"
-  image: public/quarto-gradio-bg.png
   favicon: public/favicon.png
-  open-graph: true
+  open-graph:
+    locale: en_US
+    site-name: "Quarto 🔹🔸 Gradio"
   twitter-card: true
   site-url: https://quarto-gradio.peter.gy
   repo-url: https://github.com/peter-gy/quarto-gradio

--- a/web/guide/_metadata.yml
+++ b/web/guide/_metadata.yml
@@ -1,0 +1,1 @@
+image: ../public/quarto-gradio-bg.png

--- a/web/guide/customize-python-modules/index.qmd
+++ b/web/guide/customize-python-modules/index.qmd
@@ -1,5 +1,6 @@
 ---
 title: "📦 Customize Python Modules"
+description: "Learn how to manage Python packages and specify custom dependencies for your browser-based Gradio apps."
 ---
 
 This guide will give you a brief overview of package management in a browser-based Python environment and how you can specify custom dependencies for your Gradio apps via the `quarto-gradio` extension.

--- a/web/guide/enable-coding-playground/index.qmd
+++ b/web/guide/enable-coding-playground/index.qmd
@@ -1,8 +1,7 @@
 ---
 title: "🛝 Enable Coding Playground"
+description: "This guide will show you how to convert your Gradio app into a coding playground embedded in your Quarto document. Along the way, you will also learn how to specify custom options for your embedded app that the `quarto-gradio` extension will understand and apply."
 ---
-
-This guide will show you how to convert your Gradio app into a coding playground embedded in your Quarto document. Along the way, you will also learn how to specify custom options for your embedded app that the `quarto-gradio` extension will understand and apply.
 
 ## Specifying Attributes
 

--- a/web/guide/get-started/index.qmd
+++ b/web/guide/get-started/index.qmd
@@ -1,11 +1,7 @@
 ---
 title: "🚀 Get Started"
-format:
-  html:
-    toc: true
+description: "This guide will help you get started with the `quarto-gradio` extension via a simple example. You will see how you can iterate on your Gradio app's source code in your local environment, then embed the very same app with no changes into an entirely browser-based environment."
 ---
-
-This guide will help you get started with the `quarto-gradio` extension via a simple example. You will see how you can iterate on your Gradio app's source code in your local environment, then embed the very same app with no changes into an entirely browser-based environment.
 
 ## Installation
 

--- a/web/guide/use-with-revealjs/index.qmd
+++ b/web/guide/use-with-revealjs/index.qmd
@@ -1,8 +1,7 @@
 ---
 title: "💡 Use with Reveal.js"
+description: "This guide will demonstrate how you can embed a Gradio app into a Reveal.js presentation."
 ---
-
-This guide will demonstrate how you can embed a Gradio app into a Reveal.js presentation.
 
 ## Minimal Example
 

--- a/web/index.qmd
+++ b/web/index.qmd
@@ -1,5 +1,6 @@
 ---
 title: Overview
+description: "A Quarto extension enabling the embedding of serverless Gradio Lite apps into HTML documents."
 ---
 
 This website is meant to provide a hands-on guide to making the most out of integrating [![quarto-logo](public/quarto-logo.png){width=24} Quarto](https://quarto.org){target=_blank} and [![gradio-logo](public/gradio-logo.png){width=24} Gradio Lite](https://www.gradio.app/guides/gradio-lite){target=_blank} for embedding interactive Python applications into your HTML documents. If these docs do not answer all of your questions, please don't hesitate to [start a new discussion](https://github.com/peter-gy/quarto-gradio/discussions){target=_blank} on the GitHub repository.

--- a/web/playground/_metadata.yml
+++ b/web/playground/_metadata.yml
@@ -1,3 +1,4 @@
+image: ../public/quarto-gradio-bg.png
 subtitle: Adapted from [Gradio Playground](https://gradio.app/playground/){target=_blank}.
 
 include-in-header:

--- a/web/reference/_metadata.yml
+++ b/web/reference/_metadata.yml
@@ -1,0 +1,1 @@
+image: ../public/quarto-gradio-bg.png

--- a/web/reference/index.qmd
+++ b/web/reference/index.qmd
@@ -1,5 +1,6 @@
 ---
 title: "Reference"
+description: "Configuration options and technical details of the extension."
 ---
 
 ## Supported YAML Metadata
@@ -8,15 +9,29 @@ The `quarto-gradio` extension processes the following YAML metadata:
 
 ```yml
 gradio:
-    cdn: "https://cdn.jsdelivr.net/npm/@gradio/lite"  # @gradio/lite CDN base
-    version: "latest"                                 # @gradio/lite version
-    requirements:                                     # Deps to pass to <gradio-requirements/>
+    # @gradio/lite CDN base
+    cdn: "https://cdn.jsdelivr.net/npm/@gradio/lite"
+    
+    # @gradio/lite version
+    version: "latest"                                
+    
+    # Deps to pass to <gradio-requirements/>
+    requirements:                                    
         - plotly==5.24.0
-    attributes:              # List of attributes to pass to <gradio-lite/> tag
-        theme: dark          # Optional: "dark" or "light"
-        shared-worker: false # Optional: true or false
-        playground: false    # Optional: true or false
-        layout: horizontal   # Optional: "horizontal" or "vertical"
+    
+    # List of attributes to pass to <gradio-lite/> tag
+    attributes:              
+        # Optional: "dark" or "light"
+        theme: dark          
+        
+        # Optional: true or false
+        shared-worker: false 
+        
+        # Optional: true or false
+        playground: false    
+        
+        # Optional: "horizontal" or "vertical"
+        layout: horizontal   
 ```
 
 The extension is solely responsible for passing this metadata to appropriate HTML tags defined by [@gradio/lite](https://www.npmjs.com/package/@gradio/lite){target=_blank} package. For a more detailed explanation of metadata semantics, please refer to the [Gradio Lite documentation](https://www.gradio.app/guides/gradio-lite){target=_blank}.

--- a/web/styles.css
+++ b/web/styles.css
@@ -33,3 +33,7 @@ nav.quarto-page-breadcrumbs {
 p, li {
   line-height: 1.8;
 }
+
+.description {
+  margin-top: .75em !important;
+}


### PR DESCRIPTION
The prior project-level `image: public/quarto-gradio-bg.png` config did not get applied as intended.