### PR TITLE
feat: support setting `gradio.version` meta attribute to `null`

### DIFF
--- a/_extensions/gradio/gradio-html.lua
+++ b/_extensions/gradio/gradio-html.lua
@@ -50,11 +50,17 @@ local function create_gradio_html(files, cdn, version, requirements, attributes)
     -- Build attributes string for gradio-lite tag
     local attr_str = build_attributes_string(attributes)
 
+    -- Build base URL of JS and CSS files. If version is nil, do not specify @<version>
+    local base_url = cdn
+    if version ~= nil then
+        base_url = base_url .. '@' .. version
+    end
+
     -- Create the HTML template
     return string.format([[
 <div class="quarto-gradio">
-  <script type="module" crossorigin src="%s@%s/dist/lite.js"></script>
-  <link rel="stylesheet" href="%s@%s/dist/lite.css" />
+  <script type="module" crossorigin src="%s/dist/lite.js"></script>
+  <link rel="stylesheet" href="%s/dist/lite.css" />
   <gradio-lite%s>
     <gradio-requirements>
 %s
@@ -63,8 +69,8 @@ local function create_gradio_html(files, cdn, version, requirements, attributes)
   </gradio-lite>
 </div>
 ]],
-        cdn, version,
-        cdn, version,
+        base_url,
+        base_url,
         attr_str,
         table.concat(requirements, "\n"),
         escape_html(entrypoint_content)

--- a/_extensions/gradio/gradio-meta.lua
+++ b/_extensions/gradio/gradio-meta.lua
@@ -3,7 +3,7 @@ local table = require("table-utils")
 -- Default metadata values
 local default_metadata = {
     cdn = "https://cdn.jsdelivr.net/npm/@gradio/lite",
-    version = "latest",
+    version = nil,
     requirements = {},
     attributes = {},
 }

--- a/web/reference/index.qmd
+++ b/web/reference/index.qmd
@@ -10,9 +10,9 @@ The `quarto-gradio` extension processes the following YAML metadata:
 ```yml
 gradio:
     # @gradio/lite CDN base
-    cdn: "https://cdn.jsdelivr.net/npm/@gradio/lite"
+    cdn: "https://cdn.jsdelivr.net/npm/\\@gradio/lite"
     
-    # @gradio/lite version
+    # @gradio/lite version, optional, defaults to null
     version: "latest"                                
     
     # Deps to pass to <gradio-requirements/>


### PR DESCRIPTION
This way, arbitrary CDN URLs can be supported without forcing the `https://domain.tld/<some path>@<version>` format.