### PR TITLE
docs: use custom Gradio Lite build with Pyodide 0.27.3

### DIFF
--- a/web/guide/_metadata.yml
+++ b/web/guide/_metadata.yml
@@ -1,1 +1,4 @@
 image: ../public/quarto-gradio-bg.png
+
+gradio:
+  cdn: "https://minio.peter.gy/static/npm/\\@gradio/lite"

--- a/web/guide/customize-python-modules/install-module-via-requirements.qmd
+++ b/web/guide/customize-python-modules/install-module-via-requirements.qmd
@@ -3,6 +3,7 @@ filters:
   - gradio
 
 gradio:
+  cdn: "https://minio.peter.gy/static/npm/\\@gradio/lite"
   requirements:
     - plotly==5.24.0
 ---

--- a/web/guide/enable-coding-playground/attributes-doc.qmd
+++ b/web/guide/enable-coding-playground/attributes-doc.qmd
@@ -3,6 +3,7 @@ filters:
   - gradio
 
 gradio:
+  cdn: "https://minio.peter.gy/static/npm/\\@gradio/lite"
   attributes:
     playground: true
 ---

--- a/web/guide/use-with-revealjs/reveal-gradio-lite.qmd
+++ b/web/guide/use-with-revealjs/reveal-gradio-lite.qmd
@@ -10,6 +10,7 @@ filters:
   - gradio
 
 gradio:
+  cdn: "https://minio.peter.gy/static/npm/\\@gradio/lite"
   requirements:
     - transformers-js-py
 ---

--- a/web/playground/_metadata.yml
+++ b/web/playground/_metadata.yml
@@ -11,6 +11,7 @@ include-in-header:
     </style>
 
 gradio:
+  cdn: "https://minio.peter.gy/static/npm/\\@gradio/lite"
   attributes:
     playground: true
     layout: "horizontal"


### PR DESCRIPTION
With this change the docs should not be broken on mobile.
Can be reverted once https://github.com/gradio-app/gradio/pull/10706 is merged and released to official @gradio/lite npm package.