### PR TITLE
feat: use shared worker by default for multiple Gradio Lite apps

### DIFF
--- a/_extensions/gradio/gradio-meta.lua
+++ b/_extensions/gradio/gradio-meta.lua
@@ -5,7 +5,9 @@ local default_metadata = {
     cdn = "https://cdn.jsdelivr.net/npm/@gradio/lite",
     version = nil,
     requirements = {},
-    attributes = {},
+    attributes = {
+        ['shared-worker'] = true,
+    },
 }
 
 -- JS-like map function

--- a/web/reference/index.qmd
+++ b/web/reference/index.qmd
@@ -24,8 +24,8 @@ gradio:
         # Optional: "dark" or "light"
         theme: dark          
         
-        # Optional: true or false
-        shared-worker: false 
+        # Optional: true or false, defaults to true
+        shared-worker: true
         
         # Optional: true or false
         playground: false    


### PR DESCRIPTION
This reduces the browser memory load significantly when visiting pages with multiple embedded apps, as a single loaded Pyodide env will be shared across `n` apps instead of spinning up a Pyodide environment for each.

Read more about the `SharedWorker` mode: https://www.gradio.app/guides/gradio-lite#shared-worker-mode